### PR TITLE
Update version and package dependencies

### DIFF
--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.1",
+    "version": "1.1.1",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/ModbusRx/ModbusRx.csproj
+++ b/src/ModbusRx/ModbusRx.csproj
@@ -11,7 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SerialPortRx" Version="3.0.3" />
+    <PackageReference Include="SerialPortRx" Version="3.1.1" />
+    <!-- Explicitly reference the core Rx package for reliability across TFMs -->
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump project version to 1.1.1 in Version.json. Update SerialPortRx to 3.1.1 and add explicit System.Reactive 6.0.1 reference in ModbusRx.csproj for improved reliability across target frameworks.